### PR TITLE
Add Kuadrant 'Control plane' (aka Kuadrant Operator)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+resources

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "externals/limitador"]
 	path = externals/limitador
 	url = https://github.com/Kuadrant/limitador.git
+[submodule "externals/kuadrant-operator"]
+	path = externals/kuadrant-operator
+	url = https://github.com/Kuadrant/kuadrant-operator.git

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -3,16 +3,20 @@ title: "Kuadrant Documentation"
 linkTitle: "Docs"
 ---
 
-## Operators & Controllers
+## Control plane
+
+### User guides
+ - [Simple Rate Limit For API Owners](/docs/kuadrant-operator/user-guides/simple-rl-for-api-owners.md)
+ - [Authenticated Rate Limit For API Owners](/docs/kuadrant-operator/user-guides/authenticated-rl-for-api-owners.md)
+ - [Gateway Rate Limit For Cluster Operators](/docs/kuadrant-operator/user-guides/gateway-rl-for-cluster-operators.md)
+ - [Rate-limiting and protecting an API with JSON Web Tokens (JWTs) and Kubernetes authnz using Kuadrant](/docs/kuadrant-operator/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md)
 
 ## Authorino
 
  - [Getting started](/docs/authorino/getting-started.html)
  - [User guides](/docs/authorino/user-guides.html)
 
-
 ## Limitador
 
  - [Server configuration](/docs/limitador-server/configuration.html)
  - [Redis](/docs/limitador/redis_active_active.html)
- 

--- a/content/en/docs/kuadrant-operator
+++ b/content/en/docs/kuadrant-operator
@@ -1,0 +1,1 @@
+../../../externals/kuadrant-operator/doc

--- a/data/docs/kuadrant-operator/guides.toml
+++ b/data/docs/kuadrant-operator/guides.toml
@@ -1,0 +1,19 @@
+[simple-rl-for-api-owners]
+file = "simple-rl-for-api-owners.md"
+title.en = "Simple Rate Limit For API Owners"
+weight = 10
+
+[authenticated-rl-for-api-owners]
+file = "authenticated-rl-for-api-owners.md"
+title.en = "Authenticated Rate Limit For API Owners"
+weight = 20
+
+[gateway-rl-for-cluster-operators]
+file = "gateway-rl-for-cluster-operators.md"
+title.en = "Gateway Rate Limit For Cluster Operators"
+weight = 30
+
+[authenticated-rl-with-jwt-and-k8s-authnz]
+file = "authenticated-rl-with-jwt-and-k8s-authnz.md"
+title.en = "Rate-limiting and protecting an API with JSON Web Tokens (JWTs) and Kubernetes authnz using Kuadrant"
+weight = 40

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -57,6 +57,19 @@
   {{ else -}}
   <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{  $s.Title | default $s.File.BaseFileName }}</span></a>
   {{- end }}
+  <span class="td-sidebar-nav-active-item">Control plane</span>
+  {{- if $withChild }}
+  {{- $ulNr := add $ulNr 1 }}
+  <ul class="ul-foldable">
+    <li class="align-left pl-1 td-sidebar-link td-sidebar-link__section" id="m-docshtml"><span class="td-sidebar-nav-item">User Guides</span></li>
+    {{ range sort (index .data "docs" "kuadrant-operator" "guides") "weight" -}}
+    {{ $active := and (not $shouldDelayActive) (eq $p.File.LogicalName (index . "file")) -}}
+    <li class="pl-2"><a href="/docs/kuadrant-operator/user-guides/{{ strings.TrimSuffix ".md" (index . "file") }}.html"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__page" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ index . "title" "en"}}</span></a></li>
+    {{- end }}
+  </ul>
+  {{- end }}
+</li>
+<li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
   <span class="td-sidebar-nav-active-item">Authorino</span>
   {{- if $withChild }}
   {{- $ulNr := add $ulNr 1 }}


### PR DESCRIPTION
Adds Kuadrant 'Control plane' (aka Kuadrant Operator) to the docs.

Only the 'User guides' included for now (until we have better 'basics' content for the Operator).

<img width="1727" alt="Screenshot 2022-12-21 at 13 15 00" src="https://user-images.githubusercontent.com/1842261/208903493-de7becbf-731a-4a67-855e-a958b2064648.png">
<img width="1727" alt="Screenshot 2022-12-21 at 13 15 08" src="https://user-images.githubusercontent.com/1842261/208903502-bc856a7d-c7c8-4da4-9eae-1f139abfe9d2.png">
