### PR TITLE
fix typo in the title

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -8,7 +8,7 @@ layout: layout.njk
   <div class="container">
     <div class="row">
       <div class="col-lg-6 d-flex flex-column justify-content-center pt-4 pt-lg-0 order-2 order-lg-1" data-aos="fade-up" data-aos-delay="200">
-        <h1>Gateways Policies for Kubernetes</h1>
+        <h1>Gateway Policies for Kubernetes</h1>
         <h2>Bringing together Gateway API and Open Cluster Management to help you manage, scale, load-balance and secure your Ingress Gateways as a key part of your application connectivity, in a single cluster or in the multi-cluster environment.</h2>
         <div class="d-flex justify-content-center justify-content-lg-start">
           <a href="http://docs.kuadrant.io/multicluster-gateway-controller/how-to/ocm-control-plane-walkthrough/" class="btn-get-started">Get Started</a>


### PR DESCRIPTION
"Gateways Policies for Kubernetes" → "Gateway Policies for Kubernetes"