### PR TITLE
fix/update get started link

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -12,7 +12,7 @@ tags: index-page # Note: This adds a custom class to layout.njk
         <h1>Gateway Policies for Kubernetes</h1>
         <h2>Gateways play a pivotal role in application connectivity. With Kuadrant, platform engineers and application developers can easily scale, load-balance, and protect their services and infrastructure using its powerful policy APIs.</h2>
         <div class="d-flex justify-content-center justify-content-lg-start">
-          <a href="http://docs.kuadrant.io/multicluster-gateway-controller/how-to/ocm-control-plane-walkthrough/" class="btn-get-started">Get Started</a>
+          <a href="http://docs.kuadrant.io/multicluster-gateway-controller/docs/getting-started" class="btn-get-started">Get Started</a>
           <a href="https://youtu.be/TyhpIQXiPUo" class="glightbox btn-watch-video"><i class="bi bi-play-circle"></i><span>Watch Video</span></a>
         </div>
       </div>


### PR DESCRIPTION
The current link is broken. A fix to get you to the ocm-walkthrough would be to change to 
https://docs.kuadrant.io/multicluster-gateway-controller/docs/how-to/ocm-control-plane-walkthrough/" class="btn-get-started">
But seeing as we'll be introducing a get started once [these changes](https://github.com/Kuadrant/multicluster-gateway-controller/pull/362) are published i'm updating it to that. 🤷‍♀️ 

Can be verified by running it locally and confirming the new link is used. The old link is a 404 as well. 