### PR TITLE
Redirect migration link to proper location

### DIFF
--- a/src/migrations/limitador_conditions.njk
+++ b/src/migrations/limitador_conditions.njk
@@ -1,0 +1,12 @@
+---
+permalink: /docs/limitador/migrations/conditions.html
+---
+<html>
+<header>
+    <meta http-equiv="Refresh" content="0; url='https://docs.kuadrant.io/limitador/doc/migrations/conditions/'" />
+</header>
+
+<body>
+    The docs moved to here: <a href="https://docs.kuadrant.io/limitador/doc/migrations/conditions/">https://docs.kuadrant.io/limitador/doc/migrations/conditions/</a>
+</body>
+</html>

--- a/src/migrations/pages.11tydata.json
+++ b/src/migrations/pages.11tydata.json
@@ -1,0 +1,3 @@
+{
+    "permalink": "{{ page.fileSlug }}.html"
+}


### PR DESCRIPTION
This fixes the link that [limitador outputs](https://github.com/Kuadrant/limitador/blob/5b0ff99650426546feb1fb8f517a36961603cbc6/limitador-server/src/main.rs#L251-L253) to the log, when using the deprecated condition syntax, to the new location on docs.kuadrant.io. 

so that hitting: https://kuadrant.io/docs/limitador/migrations/conditions.html would redirect to https://docs.kuadrant.io/limitador/doc/migrations/conditions/