### PR TITLE
Fix links to policy docs pages

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -55,7 +55,7 @@ tags: index-page # Note: This adds a custom class to layout.njk
         <div class="icon-box">
           <div class="icon"><i class="bx bx-shield"></i></div>
           <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy/">Protect: AuthPolicy</a></h4>
-          <p>Protect your services with our flexible and powerful [AuthPolicy API](https://docs.kuadrant.io/latest/kuadrant-operator/doc/auth/) that integrates Authentication and Authorization at the Gateway or HTTPRoute level.</p>
+          <p>Protect your services with our flexible and powerful <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/auth/">AuthPolicy API</a> that integrates Authentication and Authorization at the Gateway or HTTPRoute level.</p>
         </div>
       </div>
      <div class="col-xl-3 col-md-6 d-flex align-items-stretch mt-4 mt-xl-0" data-aos="zoom-in" data-aos-delay="300">
@@ -64,7 +64,7 @@ tags: index-page # Note: This adds a custom class to layout.njk
           <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/ratelimitpolicy/">Protect: RateLimitPolicy</a></h4>
           <p>Protect your services with our flexible and powerful <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/rate-limiting/">RateLimitPolicy</a> that integrates rate limiting at the Gateway or HTTPRoute level.</p>
         </div>
-      </div> 
+      </div>
     </div>
 
     <br><br>

--- a/src/index.njk
+++ b/src/index.njk
@@ -46,7 +46,7 @@ tags: index-page # Note: This adds a custom class to layout.njk
       <div class="col-xl-3 col-md-6 d-flex align-items-stretch mt-4 mt-md-0" data-aos="zoom-in" data-aos-delay="200">
         <div class="icon-box">
           <div class="icon"><i class="bx bx-lock"></i></div>
-          <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/tlspolicy/">Secure: TLSPolicy</a></h4>
+          <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/tls/">Secure: TLSPolicy</a></h4>
           <p>Automatically secure traffic to your Gateways with automatic ACME-based TLS integration that supports all of the main ACME providers, including Let's Encrypt</p>
         </div>
       </div>
@@ -54,14 +54,14 @@ tags: index-page # Note: This adds a custom class to layout.njk
       <div class="col-xl-3 col-md-6 d-flex align-items-stretch mt-4 mt-xl-0" data-aos="zoom-in" data-aos-delay="300">
         <div class="icon-box">
           <div class="icon"><i class="bx bx-shield"></i></div>
-          <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy/">Protect: AuthPolicy</a></h4>
+          <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/auth/">Protect: AuthPolicy</a></h4>
           <p>Protect your services with our flexible and powerful <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/auth/">AuthPolicy API</a> that integrates Authentication and Authorization at the Gateway or HTTPRoute level.</p>
         </div>
       </div>
      <div class="col-xl-3 col-md-6 d-flex align-items-stretch mt-4 mt-xl-0" data-aos="zoom-in" data-aos-delay="300">
         <div class="icon-box">
           <div class="icon"><i class="bx bx-shield"></i></div>
-          <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/ratelimitpolicy/">Protect: RateLimitPolicy</a></h4>
+          <h4><a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/rate-limiting/">Protect: RateLimitPolicy</a></h4>
           <p>Protect your services with our flexible and powerful <a href="https://docs.kuadrant.io/latest/kuadrant-operator/doc/rate-limiting/">RateLimitPolicy</a> that integrates rate limiting at the Gateway or HTTPRoute level.</p>
         </div>
       </div>


### PR DESCRIPTION
- fix rendering of link to AuthPolicy overview
- point to policy overview pages instead of API references