### PR TITLE
Update contributing guide

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -97,10 +97,10 @@ title: Kuadrant.io
           <div class="col-lg-4 col-md-6 footer-links">
             <h4>Useful Links</h4>
             <ul>
-              <li><i class="bx bx-chevron-right"></i> <a href="#hero">Home</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#features">Features</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#components">Components</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#faq">FAQs</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="/#hero">Home</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="/#features">Features</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="/#components">Components</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="/#faq">FAQs</a></li>
             </ul>
           </div>
 

--- a/src/community.md
+++ b/src/community.md
@@ -31,11 +31,7 @@ The [Kuadrant project](https://github.com/Kuadrant/) is made up of a range of co
 
 ### Getting Involved
 
-We welcome new contributors to the project, be you a seasoned multi-cluster networking expert, or someone new who is looking to improve some wonky documentation you come across. Many of our respositories include variants of a `good-first-issue` label for issues that might be good to start with. 
-
-#### Thinking about some initial contributions? 
-
-Consider fixing some bugs, trying Kuadrant and telling us about your experience or helping us hone our documentation.
+Check out the [Contributors Guide](/contributing) for ways you can get involved in the Kuadrant project.
 
 ### Social Media
 

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -62,22 +62,6 @@ Finally, it is recommended that you squash your changes into a single commit whe
 
 ## Signing Commits
 
-All commits to be accepted to Kuadrant component codebases are required to be signed. Refer to [this page](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) about signing your commits.
-
-<!--- WIP
-## Pull Request Lifecycle
-
-[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#pull-request-lifecycle)
-
-⚠️ **Explain your pull request process**
-
-## Sign Your Commits
-
-[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#sign-your-commits)
-
-⚠️ **Keep either the DCO or CLA section depending on which you use**
-
-### DCO
 Licensing is important to open source projects. It provides some assurances that
 the software will continue to be available based under the terms that the
 author(s) desired. We require that contributors sign off on commits submitted to
@@ -100,4 +84,12 @@ If you forgot to do this and have not yet pushed your changes to the remote
 repository, you can amend your commit with the sign-off by running 
 
     git commit --amend -s 
+
+<!--- WIP
+## Pull Request Lifecycle
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#pull-request-lifecycle)
+
+⚠️ **Explain your pull request process**
+
 --->


### PR DESCRIPTION
Few small things:

- add link to contributing guide from community page instead of having content embedded
- fixup relative footer links to main pages
- add DCO section for signing commits