### PR TITLE
Use node 18 for eleventy build/deploy

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
       - name: Build
         uses: TartanLlama/actions-eleventy@master
         with:


### PR DESCRIPTION
Fix for failing action https://github.com/Kuadrant/kuadrant.github.io/actions/runs/10489560237/job/29054457749