### PR TITLE
ADD: support infrastructure

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -72,6 +72,55 @@ tags: index-page # Note: This adds a custom class to layout.njk
   </div>
 </section><!-- End Features Section -->
 
+<!-- ======= Support Infrastructure Section ======= -->
+<section id="features" class="features section-bg about light">
+  <div class="container">
+
+    <div class="section-title">
+      <h2>Support Infrastructure</h2>
+      <p>Kuadrant puts in the effort of integrating with different resrouces, so you can don't have too.</p>
+    </div>
+
+    <div class="row">
+
+      <div class="col-xl-4 col-md-6 d-flex align-items-stretch mt-4 mt-md-0" data-aos="zoom-in" data-aos-delay="200">
+        <div class="icon-box">
+          <div class="icon"><i class="bx bx-buildings"></i></div>
+          <h4>Platforms</h4>
+         <p>There is a number of supported platforms</p>
+					<ul class="list-group">
+						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> Kubernetes Native</li>
+						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> OpenShift</li>
+					</ul>
+        </div>
+      </div>
+
+      <div class="col-xl-4 col-md-6 d-flex align-items-stretch mt-4 mt-xl-0" data-aos="zoom-in" data-aos-delay="300">
+        <div class="icon-box">
+          <div class="icon"><i class="bx bx-globe"></i></div>
+          <h4>Gateway Providers</h4>
+         <p>There is a number of supported gateways</p>
+					<ul class="list-group">
+						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://istio.io">Istio</a></li>
+						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://gateway.envoyproxy.io/">Envoy Gateway</a></li>
+					</ul>
+        </div>
+      </div>
+
+     <div class="col-xl-4 col-md-6 d-flex align-items-stretch mt-4 mt-xl-0" data-aos="zoom-in" data-aos-delay="300">
+        <div class="icon-box">
+          <div class="icon"><i class="bx bx-world"></i></div>
+          <h4>DNS Providers</h4>
+         <p>There is a number of supported DNS providers</p>
+					<ul class="list-group">
+						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> AWS Route 53</li>
+						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> Google Cloud DNS</li>
+					</ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section><!-- Supported Infrastructure Section -->
 
 <!-- ======= Components Section ======= -->
 <section id="components" class="components">

--- a/src/index.njk
+++ b/src/index.njk
@@ -72,13 +72,13 @@ tags: index-page # Note: This adds a custom class to layout.njk
   </div>
 </section><!-- End Features Section -->
 
-<!-- ======= Support Infrastructure Section ======= -->
+<!-- ======= Kaudrant Inegrates with Section ======= -->
 <section id="features" class="features section-bg about light">
   <div class="container">
 
     <div class="section-title">
-      <h2>Support Infrastructure</h2>
-      <p>Kuadrant puts in the effort of integrating with different resrouces, so you can don't have too.</p>
+      <h2>Kuadrant Integrations</h2>
+      <p>Kuadrant integrates seamlessly with various resources, so you don't have to.</p>
     </div>
 
     <div class="row">
@@ -87,11 +87,11 @@ tags: index-page # Note: This adds a custom class to layout.njk
         <div class="icon-box">
           <div class="icon"><i class="bx bx-buildings"></i></div>
           <h4>Platforms</h4>
-         <p>There is a number of supported platforms</p>
-					<ul class="list-group">
-						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> Kubernetes Native</li>
-						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> OpenShift</li>
-					</ul>
+         <p>Kuadrant supports multiple platforms:</p>
+		<ul class="list-group">
+			<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://kubernetes.io">Kubernetes</a></li>
+			<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://www.redhat.com/en/technologies/cloud-computing/openshift">OpenShift</a></li>
+		</ul>
         </div>
       </div>
 
@@ -99,11 +99,11 @@ tags: index-page # Note: This adds a custom class to layout.njk
         <div class="icon-box">
           <div class="icon"><i class="bx bx-globe"></i></div>
           <h4>Gateway Providers</h4>
-         <p>There is a number of supported gateways</p>
-					<ul class="list-group">
-						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://istio.io">Istio</a></li>
-						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://gateway.envoyproxy.io/">Envoy Gateway</a></li>
-					</ul>
+         <p>Kuadrant supports multiple <a href="https://gateway-api.sigs.k8s.io/">Gateway API</a> providers</p>
+		<ul class="list-group">
+			<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://istio.io">Istio</a></li>
+			<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://gateway.envoyproxy.io/">Envoy Gateway</a></li>
+		</ul>
         </div>
       </div>
 
@@ -111,16 +111,16 @@ tags: index-page # Note: This adds a custom class to layout.njk
         <div class="icon-box">
           <div class="icon"><i class="bx bx-world"></i></div>
           <h4>DNS Providers</h4>
-         <p>There is a number of supported DNS providers</p>
-					<ul class="list-group">
-						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> AWS Route 53</li>
-						<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> Google Cloud DNS</li>
-					</ul>
+         <p>Kuadrant supports multiple DNS providers</p>
+		<ul class="list-group">
+			<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://aws.amazon.com/route53/">AWS Route 53</a></li>
+			<li class="list-group-item"><span class="icon"><i class="bx bx-check-circle bx-xs"></i></span> <a href="https://cloud.google.com/dns">Google Cloud DNS</a></li>
+		</ul>
         </div>
       </div>
     </div>
   </div>
-</section><!-- Supported Infrastructure Section -->
+</section><!-- Kuadrant Integrates with Section -->
 
 <!-- ======= Components Section ======= -->
 <section id="components" class="components">


### PR DESCRIPTION
Relates to: #4 

Add a new section to the home page that lists the infrastructure that kuadrant can support.

![Screenshot From 2025-01-24 14-11-38](https://github.com/user-attachments/assets/8bf983f3-23db-4eb8-996f-a10a0d16fc35)
