### PR TITLE
Add merge queue config to workflow files

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -2,7 +2,9 @@ name: Eleventy Build
 on:
   push:
     branches: [main]
-
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
 jobs:
   build_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enables `merge-queue` for necessary workflow files. 

Issue Reference: https://github.com/Kuadrant/kuadrant.github.io/issues/74

Another PR will be required for disabling tide/prow